### PR TITLE
Initial implementation with CLI query handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 LLM-assisted tool for fetching and visualizing stock data.
 
-![CI](https://github.com/OWNER/REPO/actions/workflows/python-ci.yml/badge.svg)
-![Coverage](https://codecov.io/gh/OWNER/REPO/branch/main/graph/badge.svg)
+[![CI](https://github.com/OWNER/REPO/actions/workflows/python-ci.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/python-ci.yml)
+[![Coverage](https://codecov.io/gh/OWNER/REPO/branch/main/graph/badge.svg)](https://codecov.io/gh/OWNER/REPO)
 
 ## Quick-start for contributors
 
@@ -35,6 +35,6 @@ pre-commit install
 5. **Run example**
 
 ```bash
-python -m stock_advisor --help
+python -m stock_advisor --query "Show me AAPL for last week" --output_dir output
 ```
 

--- a/stock_advisor/__main__.py
+++ b/stock_advisor/__main__.py
@@ -1,33 +1,111 @@
-"""CLI entry point for Stock Advisor."""
+"""CLI entry point and public query handler."""
+
+from __future__ import annotations
 
 import argparse
-from .api.stock_fetch import fetch_stock_data
+import io
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Dict, Any
+
+from .api.gpt_interface import interpret_prompt
+from .api.stock_fetch import fetch_prices
+from .api.insights import generate_insights
+from .visuals.chart_line import create_line_chart
+from .visuals.chart_bar import create_bar_chart
+from .visuals.chart_volatility import create_volatility_chart
 
 DEBUG = True
 
-import logging
-import io
-
 logger = logging.getLogger(__name__)
 log_buffer = io.StringIO()
-if DEBUG:
+if DEBUG:  # pragma: no cover - debug scaffold
     handler = logging.StreamHandler(log_buffer)
     handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
     logger.setLevel(logging.DEBUG)
     logger.addHandler(handler)
 
 
-def main() -> None:
+def handle_query(
+    query: str | None = None,
+    input_data: Dict[str, Any] | None = None,
+    output_dir: str = "output",
+    show: bool = False,
+) -> tuple[str, str]:
+    """Process a user query or structured input."""
+    if query and input_data:
+        raise ValueError("Provide either query or input, not both")
+    if not (query or input_data):
+        raise ValueError("No query or input provided")
+
+    if query:
+        params = interpret_prompt(query)
+    else:
+        params = input_data or {}
+
+    ticker = params.get("ticker") or params.get("tickers", [None])[0]
+    timeframe = params.get("timeframe", "1mo")
+    interval = params.get("interval", "1d")
+    chart_type = params.get("chart_type", "line")
+
+    logger.debug(
+        "Handling query for %s timeframe=%s interval=%s chart=%s",
+        ticker,
+        timeframe,
+        interval,
+        chart_type,
+    )
+
+    data = fetch_prices(ticker, timeframe, interval)
+
+    if chart_type == "bar":
+        fig = create_bar_chart(data)
+    elif chart_type == "volatility":
+        fig = create_volatility_chart(data)
+    else:
+        fig = create_line_chart(data)
+
+    summary = generate_insights(data)
+
+    Path(output_dir).mkdir(parents=True, exist_ok=True)
+    slug = f"{ticker}_{timeframe}_{interval}"
+    html_path = Path(output_dir) / f"{slug}.html"
+    fig.write_html(str(html_path))
+    md_path = Path(output_dir) / f"{slug}.md"
+    md_path.write_text(summary)
+    if show:
+        try:  # pragma: no cover - optional UI
+            fig.show()
+        except Exception as exc:  # pragma: no cover - headless
+            logger.debug("fig.show failed: %s", exc)
+    return str(html_path), str(md_path)
+
+
+def main(argv: list[str] | None = None) -> None:
     """Run the command-line interface."""
     parser = argparse.ArgumentParser(description="Stock Advisor CLI")
-    parser.add_argument("ticker", nargs="?", help="Ticker symbol")
-    parser.add_argument("period", nargs="?", default="1mo", help="Data period")
-    args = parser.parse_args()
+    parser.add_argument("--query", help="Natural language query")
+    parser.add_argument("--input", help="JSON input string")
+    parser.add_argument("--output_dir", default="output", help="Output directory")
+    parser.add_argument("--show", action="store_true", help="Display chart")
+    args = parser.parse_args(argv)
+
     logger.debug("CLI called with %s", args)
-    # TODO: implement real CLI behavior
-    if args.ticker:
-        fetch_stock_data(args.ticker, args.period)
-    print("STUB_CLI")
+
+    input_data = None
+    if args.input:
+        input_data = json.loads(args.input)
+
+    html_path, md_path = handle_query(
+        query=args.query,
+        input_data=input_data,
+        output_dir=args.output_dir,
+        show=args.show,
+    )
+
+    print(f"Chart: {html_path}\nSummary: {md_path}")
 
 
 if __name__ == "__main__":

--- a/stock_advisor/api/stock_fetch.py
+++ b/stock_advisor/api/stock_fetch.py
@@ -1,4 +1,4 @@
-"""Stock data retrieval."""
+"""Stock data retrieval utilities."""
 
 from __future__ import annotations
 
@@ -20,13 +20,20 @@ if DEBUG:
     logger.addHandler(handler)
 
 
-def fetch_stock_data(ticker: str, period: str = "1mo") -> pd.DataFrame:
-    """Fetch historical data for a ticker."""
-    logger.debug("Fetching data for %s over %s", ticker, period)
+def fetch_prices(
+    ticker: str,
+    timeframe: str = "1mo",
+    interval: str = "1d",
+) -> pd.DataFrame:
+    """Fetch historical OHLC data."""
+    logger.debug("Fetching %s timeframe=%s interval=%s", ticker, timeframe, interval)
     try:
-        data = yf.download(ticker, period=period)
-    except Exception as exc:  # TODO: narrow exception
+        return yf.download(ticker, period=timeframe, interval=interval)
+    except Exception as exc:  # pragma: no cover - network fallback
         logger.debug("yfinance failed: %s", exc)
-        # TODO: implement Alpha Vantage fallback
+        logger.debug("STUB_ALPHA_VANTAGE")
         return pd.DataFrame()
-    return data
+
+
+# Backwards compatibility
+fetch_stock_data = fetch_prices

--- a/tests/test_gpt_interface.py
+++ b/tests/test_gpt_interface.py
@@ -3,12 +3,24 @@
 import os
 
 import pytest
-from stock_advisor.api.gpt_interface import interpret_prompt
+from stock_advisor.api.gpt_interface import interpret_prompt, FUNCTION_SCHEMA
 
 
 class DummyClient:
-    def chat(self, messages, retries=3, backoff=0.5):  # noqa: D401
-        return {"choices": [{"message": {"content": "{}"}}]}
+    def chat(
+        self, messages, functions=None, function_call=None, retries=3, backoff=0.5
+    ):  # noqa: D401
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "function_call": {
+                            "arguments": '{"ticker":"AAPL","timeframe":"1d"}'
+                        }
+                    }
+                }
+            ]
+        }
 
 
 def test_interpret_prompt_happy(monkeypatch):
@@ -17,7 +29,7 @@ def test_interpret_prompt_happy(monkeypatch):
         "stock_advisor.api.gpt_interface.OpenAIClient", lambda: DummyClient()
     )
     result = interpret_prompt("Show me AAPL")
-    assert result["tickers"] == ["AAPL"]
+    assert result["ticker"] == "AAPL"
 
 
 def test_interpret_prompt_empty(monkeypatch):
@@ -35,4 +47,9 @@ def test_interpret_prompt_integration(monkeypatch):
     if not (os.getenv("OPENAI_API_KEY") and os.getenv("RUN_OPENAI_TESTS") == "true"):
         pytest.skip("OpenAI tests disabled")
     result = interpret_prompt("Show me MSFT")
-    assert "tickers" in result
+    assert "ticker" in result
+
+
+def test_function_schema_keys():
+    assert FUNCTION_SCHEMA["name"] == "get_stock_chart"
+    assert "ticker" in FUNCTION_SCHEMA["parameters"]["properties"]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,16 +1,54 @@
 """Tests for CLI module."""
 
 import sys
+import json
+from pathlib import Path
+
 import pandas as pd
 from stock_advisor import __main__
 
 
-def test_main_calls_fetch(monkeypatch, capsys):
-    def dummy_fetch(ticker, period="1mo"):
-        return pd.DataFrame({"Close": [1]})
+class DummyFig:
+    def write_html(self, path):
+        Path(path).write_text("<html>")
 
-    monkeypatch.setattr(__main__, "fetch_stock_data", dummy_fetch)
-    monkeypatch.setattr("sys.argv", ["prog", "AAPL", "1d"])
+    def show(self):
+        pass
+
+
+def test_handle_query_creates_files(tmp_path, monkeypatch):
+    def dummy_interpret(q):
+        return {
+            "ticker": "AAPL",
+            "timeframe": "1d",
+            "interval": "1d",
+            "chart_type": "line",
+        }
+
+    monkeypatch.setattr(__main__, "interpret_prompt", dummy_interpret)
+    monkeypatch.setattr(
+        __main__, "fetch_prices", lambda *a, **k: pd.DataFrame({"Close": [1, 2, 3]})
+    )
+    monkeypatch.setattr(__main__, "generate_insights", lambda df: "summary")
+    monkeypatch.setattr(__main__, "create_line_chart", lambda df: DummyFig())
+
+    html, md = __main__.handle_query(query="test", output_dir=tmp_path)
+    assert Path(html).exists()
+    assert Path(md).exists()
+
+
+def test_main_cli(monkeypatch, capsys):
+    monkeypatch.setattr(__main__, "handle_query", lambda **kwargs: ("a.html", "a.md"))
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "prog",
+            "--query",
+            "Show AAPL",
+            "--output_dir",
+            "out",
+        ],
+    )
     __main__.main()
     captured = capsys.readouterr()
-    assert "STUB_CLI" in captured.out
+    assert "Chart:" in captured.out

--- a/tests/test_stock_fetch.py
+++ b/tests/test_stock_fetch.py
@@ -3,26 +3,26 @@
 import pandas as pd
 import pytest
 
-from stock_advisor.api.stock_fetch import fetch_stock_data
+from stock_advisor.api.stock_fetch import fetch_prices
 
 
-def test_fetch_stock_data_happy(monkeypatch):
+def test_fetch_prices_happy(monkeypatch):
     """Happy path for data fetch."""
 
     def dummy_download(*args, **kwargs):
         return pd.DataFrame({"Close": [1, 2, 3]})
 
     monkeypatch.setattr("yfinance.download", dummy_download)
-    data = fetch_stock_data("AAPL", "1d")
+    data = fetch_prices("AAPL", "1d", "1d")
     assert not data.empty
 
 
-def test_fetch_stock_data_bad_ticker(monkeypatch):
+def test_fetch_prices_bad_ticker(monkeypatch):
     """Edge case for bad ticker."""
 
     def dummy_download(*args, **kwargs):
         raise ValueError("invalid ticker")
 
     monkeypatch.setattr("yfinance.download", dummy_download)
-    data = fetch_stock_data("BAD", "1d")
+    data = fetch_prices("BAD", "1d", "1d")
     assert data.empty


### PR DESCRIPTION
## Summary
- implement query/JSON handling in CLI
- add OpenAI function-calling schema and parser
- support price fetching with Alpha Vantage stub
- update tests for new features and maintain high coverage
- update README badges and usage example

## Testing
- `pytest -q -m "not integration_openai" --cov=stock_advisor`

------
https://chatgpt.com/codex/tasks/task_e_6848e9727268833183f5aef5f61b9cf4