### PR TITLE
Add centralized config and integration test gating

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,11 @@ __pycache__/
 venv/
 ENV/
 
+.pytest_cache/
+.mypy_cache/
+
 .vscode/
+.idea/
 
 .env
+

--- a/README.md
+++ b/README.md
@@ -38,3 +38,10 @@ pre-commit install
 python -m stock_advisor --query "Show me AAPL for last week" --output_dir output
 ```
 
+```yaml
+# ── Secrets in CI ───────────────────────
+env:
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  RUN_OPENAI_TESTS: "true"
+```
+

--- a/config.py
+++ b/config.py
@@ -1,0 +1,35 @@
+"""Centralised settings for ChatGPT Stock Advisor."""
+from pathlib import Path
+from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic import ValidationError, model_validator
+from dotenv import load_dotenv
+
+# Load .env if present (noop in most CI environments)
+load_dotenv(Path(__file__).with_name(".env"))
+
+class Settings(BaseSettings):
+    """Strongly-typed runtime configuration."""
+
+    openai_api_key: str | None = None
+    run_openai_tests: bool = False
+
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        case_sensitive=True,
+    )
+
+    @model_validator(mode="after")
+    def _check_api_key(cls, values: "Settings") -> "Settings":
+        if values.run_openai_tests and not values.openai_api_key:
+            raise ValidationError([
+                {
+                    "loc": ("openai_api_key",),
+                    "msg": "openai_api_key required when run_openai_tests is True",
+                    "type": "value_error",
+                }
+            ], Settings)
+        return values
+
+
+settings = Settings()  # import-safe singleton

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "plotly==5.22.0",
     "yfinance==0.2.37",
     "python-dotenv==1.0.1",
+    "pydantic-settings==2.2.1",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ openai>=1.58
 
 # Environment/config
 python-dotenv==1.0.1
+pydantic-settings==2.2.1
 
 # Testing
 pytest==8.2.2

--- a/stock_advisor/__main__.py
+++ b/stock_advisor/__main__.py
@@ -90,9 +90,18 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument("--input", help="JSON input string")
     parser.add_argument("--output_dir", default="output", help="Output directory")
     parser.add_argument("--show", action="store_true", help="Display chart")
+    parser.add_argument(
+        "--use-env",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Load variables from .env (default) or rely solely on OS env vars.",
+    )
     args = parser.parse_args(argv)
 
     logger.debug("CLI called with %s", args)
+
+    if not args.use_env:
+        os.environ.pop("PYTHON_DOTENV", None)
 
     input_data = None
     if args.input:

--- a/stock_advisor/api/gpt_interface.py
+++ b/stock_advisor/api/gpt_interface.py
@@ -9,6 +9,7 @@ import re
 from typing import Dict, Any
 
 from stock_advisor.openai_client import OpenAIClient
+from config import settings
 
 DEBUG = True
 
@@ -35,7 +36,7 @@ FUNCTION_SCHEMA = {
     },
 }
 
-client = OpenAIClient()
+client = OpenAIClient(api_key=settings.openai_api_key)
 
 
 def interpret_prompt(prompt: str) -> Dict[str, Any]:

--- a/stock_advisor/api/insights.py
+++ b/stock_advisor/api/insights.py
@@ -9,6 +9,7 @@ from typing import Any
 import pandas as pd
 
 from stock_advisor.openai_client import OpenAIClient
+from config import settings
 
 DEBUG = True
 
@@ -20,7 +21,7 @@ if DEBUG:
     logger.setLevel(logging.DEBUG)
     logger.addHandler(handler)
 
-client = OpenAIClient()
+client = OpenAIClient(api_key=settings.openai_api_key)
 
 
 def generate_insights(data: pd.DataFrame) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,12 @@
 import os
+import sys
+from pathlib import Path
 import pytest
+
+# Ensure project root is importable for `config` module
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
 
 def pytest_configure(config: pytest.Config) -> None:  # pragma: no cover

--- a/tests/test_openai_integration.py
+++ b/tests/test_openai_integration.py
@@ -1,0 +1,21 @@
+"""
+Runs only when RUN_OPENAI_TESTS=true *and* OPENAI_API_KEY is set.
+Execute with: pytest -q tests/test_openai_integration.py
+"""
+import pytest
+from openai import OpenAI
+from config import settings
+
+_skip = not settings.run_openai_tests or not settings.openai_api_key
+pytestmark = pytest.mark.skipif(_skip, reason="Integration tests disabled")
+
+
+def test_chat_completion_smoke() -> None:
+    """Minimal round-trip to verify credentials are valid."""
+    client = OpenAI(api_key=settings.openai_api_key)
+    resp = client.chat.completions.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": "ping"}],
+        max_tokens=1,
+    )
+    assert resp.choices[0].message.content.strip()


### PR DESCRIPTION
## Summary
- add config layer using pydantic-settings and dotenv
- gate OpenAI integration tests via new config
- expose optional `--use-env/--no-env` flag for the CLI
- adjust tests to import project root
- update dependencies and ignore common env/IDE files
- document CI secrets usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849dc593b2c8331ac0c1c9747b70353