### PR TITLE
Implement multi-ticker charts and candlestick support

### DIFF
--- a/stock_advisor/visuals/chart_bar.py
+++ b/stock_advisor/visuals/chart_bar.py
@@ -7,6 +7,7 @@ import logging
 
 import pandas as pd
 import plotly.graph_objects as go
+from stock_advisor.api.stock_fetch import fetch_prices
 
 DEBUG = True
 
@@ -19,9 +20,25 @@ if DEBUG:
     logger.addHandler(handler)
 
 
+def plot_peer_comparison(tickers: list[str], timeframe: str) -> go.Figure:
+    """Plot percentage returns for multiple tickers."""
+    logger.debug("Creating peer comparison for %s", tickers)
+    returns: dict[str, float] = {}
+    for tk in tickers:
+        data = fetch_prices(tk, timeframe, "1d")
+        if not data.empty and "Close" in data:
+            start = data["Close"].iloc[0]
+            end = data["Close"].iloc[-1]
+            if start != 0:
+                returns[tk] = (end - start) / start * 100
+    fig = go.Figure(go.Bar(x=list(returns.keys()), y=list(returns.values())))
+    fig.update_layout(yaxis_title="Return %")
+    return fig
+
+
 def create_bar_chart(data: pd.DataFrame) -> go.Figure:
-    """Return a peer comparison bar chart."""
-    logger.debug("Creating bar chart")
+    """Backward compatible chart from preloaded data."""
+    logger.debug("create_bar_chart backward compatibility")
     fig = go.Figure()
     for column in data.columns:
         fig.add_trace(go.Bar(name=column, y=data[column]))

--- a/stock_advisor/visuals/chart_candlestick.py
+++ b/stock_advisor/visuals/chart_candlestick.py
@@ -1,0 +1,40 @@
+"""Interactive candlestick chart."""
+
+from __future__ import annotations
+
+import io
+import logging
+
+import plotly.graph_objects as go
+
+from stock_advisor.api.stock_fetch import fetch_prices
+
+DEBUG = True
+
+logger = logging.getLogger(__name__)
+log_buffer = io.StringIO()
+if DEBUG:
+    handler = logging.StreamHandler(log_buffer)
+    handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+    logger.setLevel(logging.DEBUG)
+    logger.addHandler(handler)
+
+
+def plot_candlestick(ticker: str, timeframe: str, interval: str) -> go.Figure:
+    """Render an interactive OHLC candlestick chart."""
+    logger.debug("Creating candlestick for %s", ticker)
+    data = fetch_prices(ticker, timeframe, interval)
+    fig = go.Figure()
+    if not data.empty:
+        fig.add_trace(
+            go.Candlestick(
+                x=data.index,
+                open=data["Open"],
+                high=data["High"],
+                low=data["Low"],
+                close=data["Close"],
+                name=ticker,
+            )
+        )
+        fig.update_layout(xaxis_rangeslider_visible=True)
+    return fig

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -3,31 +3,66 @@
 import pandas as pd
 import plotly.graph_objects as go
 
-from stock_advisor.visuals.chart_line import create_line_chart
-from stock_advisor.visuals.chart_bar import create_bar_chart
+from stock_advisor.visuals.chart_line import chart_line
+from stock_advisor.visuals.chart_bar import plot_peer_comparison
+from stock_advisor.visuals.chart_candlestick import plot_candlestick
 from stock_advisor.visuals.chart_volatility import create_volatility_chart
 
 
-def test_create_line_chart_smoke():
-    """Smoke test for line chart."""
-    df = pd.DataFrame({("Close", "AAPL"): [1, 2, 3]})
-    fig = create_line_chart(df, "AAPL")
+def test_chart_line_smoke(monkeypatch):
+    """Smoke test for multi-series line chart."""
+
+    def dummy_fetch(ticker, timeframe, interval):
+        return pd.DataFrame({"Close": [1, 2, 3]})
+
+    monkeypatch.setattr("stock_advisor.visuals.chart_line.fetch_prices", dummy_fetch)
+    fig = chart_line(["AAPL", "MSFT"], "1d", "1d")
     assert isinstance(fig, go.Figure)
-
-
-def test_create_line_chart_empty():
-    """Edge case with empty data."""
-    fig = create_line_chart(pd.DataFrame(), "AAPL")
-    assert isinstance(fig, go.Figure)
-
-
-def test_create_bar_chart_smoke():
-    df = pd.DataFrame({"AAPL": [1, 2], "MSFT": [2, 3]})
-    fig = create_bar_chart(df)
     assert len(fig.data) == 2
+
+
+def test_chart_line_empty(monkeypatch):
+    """Edge case with empty data."""
+
+    monkeypatch.setattr(
+        "stock_advisor.visuals.chart_line.fetch_prices",
+        lambda *a, **k: pd.DataFrame(),
+    )
+    fig = chart_line(["AAPL"], "1d", "1d")
+    assert isinstance(fig, go.Figure)
+
+
+def test_plot_peer_comparison(monkeypatch):
+    def dummy_fetch(*args, **kwargs):
+        return pd.DataFrame({"Close": [1, 2]})
+
+    monkeypatch.setattr(
+        "stock_advisor.visuals.chart_bar.fetch_prices", dummy_fetch
+    )
+    fig = plot_peer_comparison(["AAPL", "MSFT"], "1mo")
+    assert isinstance(fig, go.Figure)
+    assert len(fig.data[0].x) == 2
 
 
 def test_create_volatility_chart_smoke():
     df = pd.DataFrame({("Close", "AAPL"): [1, 2, 3, 4, 5, 6]})
     fig = create_volatility_chart(df, "AAPL")
     assert isinstance(fig, go.Figure)
+
+
+def test_plot_candlestick(monkeypatch):
+    data = pd.DataFrame(
+        {
+            "Open": [1],
+            "High": [2],
+            "Low": [1],
+            "Close": [1.5],
+        }
+    )
+    monkeypatch.setattr(
+        "stock_advisor.visuals.chart_candlestick.fetch_prices",
+        lambda *a, **k: data,
+    )
+    fig = plot_candlestick("AAPL", "1d", "1m")
+    assert isinstance(fig, go.Figure)
+    assert len(fig.data) == 1

--- a/tests/test_query_routing.py
+++ b/tests/test_query_routing.py
@@ -1,0 +1,115 @@
+import pandas as pd
+from pathlib import Path
+
+from stock_advisor.api.query import handle_query
+
+
+class DummyFig:
+    def write_html(self, path):
+        Path(path).write_text("<html>")
+
+    def show(self):
+        pass
+
+
+def _patch_common(monkeypatch):
+    monkeypatch.setattr(
+        "stock_advisor.api.query.fetch_prices",
+        lambda *a, **k: pd.DataFrame(
+            {
+                "Open": [1],
+                "High": [2],
+                "Low": [1],
+                "Close": [1.5],
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        "stock_advisor.api.query.generate_insights", lambda df: "summary"
+    )
+
+
+def test_route_single_candlestick(tmp_path, monkeypatch):
+    called = {}
+
+    def dummy(fig_name):
+        def _inner(*args, **kwargs):
+            called[fig_name] = True
+            return DummyFig()
+
+        return _inner
+
+    _patch_common(monkeypatch)
+    monkeypatch.setattr(
+        "stock_advisor.api.query.plot_candlestick", dummy("candle")
+    )
+    monkeypatch.setattr("stock_advisor.api.query.chart_line", dummy("line"))
+    monkeypatch.setattr(
+        "stock_advisor.api.query.plot_peer_comparison", dummy("bar")
+    )
+
+    handle_query(input_data={"ticker": "AAPL"}, output_dir=tmp_path)
+    assert called.get("candle")
+    assert not called.get("line")
+    assert not called.get("bar")
+
+
+def test_route_line_introspection(tmp_path, monkeypatch):
+    called = {}
+
+    def dummy(fig_name):
+        def _inner(*args, **kwargs):
+            called[fig_name] = True
+            return DummyFig()
+
+        return _inner
+
+    _patch_common(monkeypatch)
+    monkeypatch.setattr("stock_advisor.api.query.chart_line", dummy("line"))
+    monkeypatch.setattr(
+        "stock_advisor.api.query.plot_peer_comparison", dummy("bar")
+    )
+    monkeypatch.setattr(
+        "stock_advisor.api.query.plot_candlestick", dummy("candle")
+    )
+
+    handle_query(
+        input_data={
+            "ticker": "MSFT",
+            "compare": "AAPL",
+            "timeframe": "1d",
+            "interval": "5m",
+        },
+        output_dir=tmp_path,
+    )
+    assert called.get("line")
+    assert not called.get("bar")
+    assert not called.get("candle")
+
+
+def test_route_general_comparison(tmp_path, monkeypatch):
+    called = {}
+
+    def dummy(fig_name):
+        def _inner(*args, **kwargs):
+            called[fig_name] = True
+            return DummyFig()
+
+        return _inner
+
+    _patch_common(monkeypatch)
+    monkeypatch.setattr(
+        "stock_advisor.api.query.plot_peer_comparison", dummy("bar")
+    )
+    monkeypatch.setattr("stock_advisor.api.query.chart_line", dummy("line"))
+    monkeypatch.setattr(
+        "stock_advisor.api.query.plot_candlestick", dummy("candle")
+    )
+
+    handle_query(
+        input_data={"ticker": "MSFT", "compare": "AAPL"},
+        output_dir=tmp_path,
+    )
+    assert called.get("bar")
+    assert not called.get("line")
+    assert not called.get("candle")


### PR DESCRIPTION
## Summary
- add `chart_candlestick` module with `plot_candlestick`
- extend `chart_line` with `chart_line` for multi-ticker overlays
- update bar chart to `plot_peer_comparison`
- route queries in `handle_query` based on `compare` and `chart_type`
- test new chart functions and routing logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c9ff3d97c8331adc128bc8fa43f08